### PR TITLE
Rabbitmq migration

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,3 @@ appVersion: "2024.9.2"
 description: BDBA Helm chart
 name: bdba
 version: "2024.9.2"
-dependencies:
-- name: rabbitmq
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: "6.18.2"
-  condition: rabbitmq.enabled

--- a/README.md
+++ b/README.md
@@ -159,13 +159,16 @@ using external rabbitmq, you can ignore this.
 There is no easy migration path of old rabbitmq volume since there will be many major rabbitmq version upgrades.
 Existing work queues will be lost during update.
 
-Upgrade will create a new rabbitmq volume. After the upgrade and when old rabbitmq is no longer running,
-you should remove the volume associated with it. It is most likely called "persistence-bdba-rabbitmq-server-0"
-in the namespace bdba was installed. To remove it after upgrade, issue
+Before upgrading, old rabbitmq instance must be removed and ensured that no leftovers from rabbitmq
+helm chart are in working directory.
 
 ```console
-$ kubectl delete pvc -n <namespace> persistence-bdba-rabbitmq-server-0
+$ rm -rf charts/||true
+$ kubectl delete statefulset -n <namespace> <release>-rabbitmq
+$ kubectl delete pvc -n <namespace> data-<release>-rabbitmq-0
 ```
+
+After old rabbitmq is removed, upgrading BDBA can continue as usual.
 
 ## Upgrading to 2023.9.0
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ You can deploy Black Duck Binary Analysis on a Kubernetes cluster either by usin
 * Added instructions for populating the database in airgapped deployment
 * `frontend.web.rootUrl` is now used for SSO endpoints as well, instead of guessing from HTTP request.
 
+## Upgrading to XXXX.XX.XX
+
+BDBA helm chart XXXX.XX.X moves away from bitnami rabbitmq helm chart to internal one. In case you are
+using external rabbitmq, you can ignore this.
+
+There is no easy migration path of old rabbitmq volume since there will be many major rabbitmq version upgrades.
+Existing work queues will be lost during update.
+
+Upgrade will create a new rabbitmq volume. After the upgrade and when old rabbitmq is no longer running,
+you should remove the volume associated with it. It is most likely called "persistence-bdba-rabbitmq-server-0"
+in the namespace bdba was installed. To remove it after upgrade, issue
+
+```console
+$ kubectl delete pvc -n <namespace> persistence-bdba-rabbitmq-server-0
+```
+
 ## Upgrading to 2023.9.0
 
 BDBA helm chart 2023.9.0 upgrades internal PostgreSQL to 15. If you are using external postgresql, you can

--- a/files/rabbitmq.conf
+++ b/files/rabbitmq.conf
@@ -1,0 +1,4 @@
+loopback_users.guest = false
+consumer_timeout = 86400000
+vm_memory_high_watermark.absolute = 1GB
+log.file.level = info

--- a/templates/rabbitmq.yaml
+++ b/templates/rabbitmq.yaml
@@ -1,23 +1,4 @@
 {{- if .Values.rabbitmq.enabled }}
-{{- if .Values.rabbitmq.persistence.enabled }}
-{{- if not .Values.rabbitmq.persistence.existingClaim }}
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ template "bdba.rabbitmq.fullname" . }}
-  labels:
-{{ include "bdba.labels" . | indent 4 }}
-spec:
-  accessModes:
-    - "ReadWriteOnce"
-  resources:
-    requests:
-      storage: {{ .Values.rabbitmq.persistence.size | quote }}
-{{- if .Values.rabbitmq.persistence.storageClass }}
-  storageClassName: "{{ .Values.rabbitmq.persistence.storageClass }}"
-{{- end }}
-{{- end }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -35,30 +16,14 @@ spec:
   selector:
     app: "rabbitmq"
     release: {{ .Release.Name }}
-#---
-#{{- if not .Values.global.rabbitmq.existingSecret }}
-#apiVersion: v1
-#kind: Secret
-#metadata:
-#  name: {{ template "bdba.rabbitmq.fullname" . }}
-#  labels:
-#{{ include "bdba.labels" . | indent 4 }}
-#type: Opaque
-#data:
-#  {{ if .Values.rabbitmq.postgresqlPassword }}
-#  postgresql-password: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
-#  {{- end }}
-#---
-#{{- end }}
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  name: {{ template "bdba.postgresql.fullname" . }}-configuration
-#data:
-#  postgresql.conf: |-
-#{{ .Files.Get "files/postgresql.conf" | indent 4 }}
-#  pg_hba.conf: |-
-#     host all all all {{ .Values.postgresql.authScheme | default "scram-sha-256" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bdba.rabbitmq.fullname" . }}-configuration
+data:
+  rabbitmq.conf: |-
+{{ .Files.Get "files/rabbitmq.conf" | indent 4 }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -93,57 +58,51 @@ spec:
         - name: {{ template "bdba.rabbitmq.fullname" . }}
           image: "{{ .Values.rabbitmq.image.repository }}:{{ .Values.rabbitmq.image.tag }}"
           imagePullPolicy: {{ .Values.rabbitmq.image.pullPolicy }}
-#          {{- if .Values.postgresql.livenessProbe.enabled }}
-#          livenessProbe:
-#            exec:
-#              command:
-#                - /bin/sh
-#                - -c
-#                - exec pg_isready -U {{ .Values.postgresql.postgresqlUsername | quote }} -d {{ .Values.postgresql.postgresqlDatabase | quote }} -h 127.0.0.1 -p 5432
-#            initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
-#            periodSeconds: {{ .Values.postgresql.livenessProbe.periodSeconds }}
-#            timeoutSeconds: {{ .Values.postgresql.livenessProbe.timeoutSeconds }}
-#            successThreshold: {{ .Values.postgresql.livenessProbe.successThreshold }}
-#            failureThreshold: {{ .Values.postgresql.livenessProbe.failureThreshold }}
-#          {{- end }}
-#          {{- if .Values.postgresql.readinessProbe.enabled }}
-#          readinessProbe:
-#            exec:
-#              command:
-#                - /bin/sh
-#                - -c
-#                - exec pg_isready -U {{ .Values.postgresql.postgresqlUsername | quote }} -d {{ .Values.postgresql.postgresqlDatabase | quote }} -h 127.0.0.1 -p 5432
-#            initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
-#            periodSeconds: {{ .Values.postgresql.readinessProbe.periodSeconds }}
-#            timeoutSeconds: {{ .Values.postgresql.readinessProbe.timeoutSeconds }}
-#            successThreshold: {{ .Values.postgresql.readinessProbe.successThreshold }}
-#            failureThreshold: {{ .Values.postgresql.readinessProbe.failureThreshold }}
-#          {{- end }}
-#          env:
-#            - name: POSTGRES_USER
-#              value: {{ .Values.postgresql.postgresqlUsername | quote }}
-#            - name: POSTGRES_DATABASE
-#              value: {{ .Values.postgresql.postgresqlDatabase | quote }}
-#            - name: PGDATA
-#              value: "/data/postgresql/data"
-#            - name: POSTGRES_PASSWORD
-#              valueFrom:
-#                secretKeyRef:
-#                  name: {{ template "bdba.postgresql.passwordSecretName" . }}
-#                  key: postgresql-password    
-#          {{- if .Values.postgresql.resources }}
+          {{- if .Values.rabbitmq.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - "-q" 
+                - ping
+            initialDelaySeconds: {{ .Values.rabbitmq.livenessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.rabbitmq.livenessProbe.periodSeconds | default 60 }}
+            timeoutSeconds: {{ .Values.rabbitmq.livenessProbe.timeoutSeconds | default 10 }}
+            successThreshold: {{ .Values.rabbitmq.livenessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.rabbitmq.livenessProbe.failureThreshold | default 1 }}
+          {{- end }}
+          {{- if .Values.rabbitmq.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - "-q" 
+                - ping
+            initialDelaySeconds: {{ .Values.rabbitmq.readinessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.rabbitmq.readinessProbe.periodSeconds | default 60 }}
+            timeoutSeconds: {{ .Values.rabbitmq.readinessProbe.timeoutSeconds | default 10 }}
+            successThreshold: {{ .Values.rabbitmq.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.rabbitmq.readinessProbe.failureThreshold | default 1 }}
+          {{- end }}
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: {{ .Values.rabbitmq.rabbitmq.username | quote }}
+            - name: RABBITMQ_CONFIG_FILE
+              value: "/conf/rabbitmq.conf"
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "bdba.rabbitmq.passwordSecretName" . }}
+                  key: rabbitmq-password    
+          {{- if .Values.rabbitmq.resources }}
           resources: {{- toYaml .Values.rabbitmq.resources | nindent 12 }}
           {{- end }}                  
           volumeMounts:
             - name: data
-              mountPath: "/data/rabbitmq"
-#            - name: {{ template "bdba.postgresql.fullname" . }}-configuration
-#              mountPath: "/pgconf"
-#              readOnly: true
-#          command:
-#            - "postgres"
-#            - "-c"
-#            - "config_file=/pgconf/postgresql.conf"
+              mountPath: "/var/lib/rabbitmq"
+            - name: {{ template "bdba.rabbitmq.fullname" . }}-configuration
+              mountPath: "/conf"
+              readOnly: true
       {{- if .Values.rabbitmq.securityContext.enabled }}
       securityContext:
         runAsNonRoot: true
@@ -151,9 +110,9 @@ spec:
         fsGroup: {{ .Values.rabbitmq.securityContext.fsGroup | default 1001 }}
       {{- end }}
       volumes:
-#        - name: {{ template "bdba.postgresql.fullname" . }}-configuration
-#          configMap:
-#            name: {{ template "bdba.postgresql.fullname" . }}-configuration
+        - name: {{ template "bdba.rabbitmq.fullname" . }}-configuration
+          configMap:
+            name: {{ template "bdba.rabbitmq.fullname" . }}-configuration
 {{- if .Values.rabbitmq.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/templates/rabbitmq.yaml
+++ b/templates/rabbitmq.yaml
@@ -1,0 +1,181 @@
+{{- if .Values.rabbitmq.enabled }}
+{{- if .Values.rabbitmq.persistence.enabled }}
+{{- if not .Values.rabbitmq.persistence.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "bdba.rabbitmq.fullname" . }}
+  labels:
+{{ include "bdba.labels" . | indent 4 }}
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ .Values.rabbitmq.persistence.size | quote }}
+{{- if .Values.rabbitmq.persistence.storageClass }}
+  storageClassName: "{{ .Values.rabbitmq.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "bdba.rabbitmq.fullname" . }}
+  labels:
+{{ include "bdba.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 5672
+      targetPort: 5672
+      protocol: TCP
+      name: rabbitmq
+  selector:
+    app: "rabbitmq"
+    release: {{ .Release.Name }}
+#---
+#{{- if not .Values.global.rabbitmq.existingSecret }}
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: {{ template "bdba.rabbitmq.fullname" . }}
+#  labels:
+#{{ include "bdba.labels" . | indent 4 }}
+#type: Opaque
+#data:
+#  {{ if .Values.rabbitmq.postgresqlPassword }}
+#  postgresql-password: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+#  {{- end }}
+#---
+#{{- end }}
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: {{ template "bdba.postgresql.fullname" . }}-configuration
+#data:
+#  postgresql.conf: |-
+#{{ .Files.Get "files/postgresql.conf" | indent 4 }}
+#  pg_hba.conf: |-
+#     host all all all {{ .Values.postgresql.authScheme | default "scram-sha-256" }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "bdba.rabbitmq.fullname" . }}
+  labels:
+    app: "rabbitmq"
+{{ include "bdba.labels" . | indent 4 }}
+spec:
+  serviceName: {{ template "bdba.rabbitmq.fullname" . }}-headless
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: "rabbitmq"
+      release: {{ .Release.Name }}
+      role: master
+  template:
+    metadata:
+      name: {{ template "bdba.rabbitmq.fullname" . }}
+      labels:
+        app: "rabbitmq"
+        release: {{ .Release.Name }}
+        role: master
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "bdba.rabbitmq.fullname" . }}
+          image: "{{ .Values.rabbitmq.image.repository }}:{{ .Values.rabbitmq.image.tag }}"
+          imagePullPolicy: {{ .Values.rabbitmq.image.pullPolicy }}
+#          {{- if .Values.postgresql.livenessProbe.enabled }}
+#          livenessProbe:
+#            exec:
+#              command:
+#                - /bin/sh
+#                - -c
+#                - exec pg_isready -U {{ .Values.postgresql.postgresqlUsername | quote }} -d {{ .Values.postgresql.postgresqlDatabase | quote }} -h 127.0.0.1 -p 5432
+#            initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
+#            periodSeconds: {{ .Values.postgresql.livenessProbe.periodSeconds }}
+#            timeoutSeconds: {{ .Values.postgresql.livenessProbe.timeoutSeconds }}
+#            successThreshold: {{ .Values.postgresql.livenessProbe.successThreshold }}
+#            failureThreshold: {{ .Values.postgresql.livenessProbe.failureThreshold }}
+#          {{- end }}
+#          {{- if .Values.postgresql.readinessProbe.enabled }}
+#          readinessProbe:
+#            exec:
+#              command:
+#                - /bin/sh
+#                - -c
+#                - exec pg_isready -U {{ .Values.postgresql.postgresqlUsername | quote }} -d {{ .Values.postgresql.postgresqlDatabase | quote }} -h 127.0.0.1 -p 5432
+#            initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
+#            periodSeconds: {{ .Values.postgresql.readinessProbe.periodSeconds }}
+#            timeoutSeconds: {{ .Values.postgresql.readinessProbe.timeoutSeconds }}
+#            successThreshold: {{ .Values.postgresql.readinessProbe.successThreshold }}
+#            failureThreshold: {{ .Values.postgresql.readinessProbe.failureThreshold }}
+#          {{- end }}
+#          env:
+#            - name: POSTGRES_USER
+#              value: {{ .Values.postgresql.postgresqlUsername | quote }}
+#            - name: POSTGRES_DATABASE
+#              value: {{ .Values.postgresql.postgresqlDatabase | quote }}
+#            - name: PGDATA
+#              value: "/data/postgresql/data"
+#            - name: POSTGRES_PASSWORD
+#              valueFrom:
+#                secretKeyRef:
+#                  name: {{ template "bdba.postgresql.passwordSecretName" . }}
+#                  key: postgresql-password    
+#          {{- if .Values.postgresql.resources }}
+          resources: {{- toYaml .Values.rabbitmq.resources | nindent 12 }}
+          {{- end }}                  
+          volumeMounts:
+            - name: data
+              mountPath: "/data/rabbitmq"
+#            - name: {{ template "bdba.postgresql.fullname" . }}-configuration
+#              mountPath: "/pgconf"
+#              readOnly: true
+#          command:
+#            - "postgres"
+#            - "-c"
+#            - "config_file=/pgconf/postgresql.conf"
+      {{- if .Values.rabbitmq.securityContext.enabled }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.rabbitmq.securityContext.runAsUser | default 1001 }}
+        fsGroup: {{ .Values.rabbitmq.securityContext.fsGroup | default 1001 }}
+      {{- end }}
+      volumes:
+#        - name: {{ template "bdba.postgresql.fullname" . }}-configuration
+#          configMap:
+#            name: {{ template "bdba.postgresql.fullname" . }}-configuration
+{{- if .Values.rabbitmq.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+{{- with .Values.rabbitmq.persistence.existingClaim }}
+            claimName: {{ tpl . $ }}
+{{- end }}
+{{- else if not .Values.rabbitmq.persistence.existingClaim }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      {{- with .Values.rabbitmq.persistence.annotations }}
+        annotations:
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.rabbitmq.persistence.size | quote }}
+        storageClassName: {{ .Values.rabbitmq.persistence.storageClass }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -265,7 +265,9 @@ minio:
 
 rabbitmq:
   image:
-    tag: 3.10.25-debian-12-r20
+    repository: "docker.io/library/rabbitmq"
+    # Suffix this with -management if access to rabbitmq management is needed
+    tag: "4.0.4"
   enabled: true
   rabbitmq:
     username: bdba
@@ -273,20 +275,6 @@ rabbitmq:
     ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
     ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
     ## hard-coded to prevent restarts of rabbitmq (not used for security reasons)
-    existingErlangSecret: bdba-rabbitmq-erlang-cookie-secret
-    configuration: |-
-      ## Clustering
-      #      cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
-      #      cluster_formation.k8s.host = kubernetes.default.svc.{{.Values.rabbitmq.rabbitmq.clustering.k8s_domain}}
-      #      cluster_formation.node_cleanup.interval = 10
-      #      cluster_formation.node_cleanup.only_log_warning = true
-      #      cluster_partition_handling = autoheal
-      # queue master locator
-      queue_master_locator=min-masters
-      # enable guest user
-      loopback_users.guest = false
-      consumer_timeout = 86400000
-    plugins: rabbitmq_management
   persistence:
     enabled: true
     size: 8Gi
@@ -294,6 +282,22 @@ rabbitmq:
     requests:
       memory: "1Gi"
       cpu: 100m
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 2
+    timeoutSeconds: 2
+    failureThreshold: 6
+    successThreshold: 1
+
 #   limits:
 #      memory: "1Gi"
 #      cpu: 100m

--- a/values.yaml
+++ b/values.yaml
@@ -288,6 +288,7 @@ rabbitmq:
       consumer_timeout = 86400000
     plugins: rabbitmq_management
   persistence:
+    enabled: true
     size: 8Gi
   resources:
     requests:


### PR DESCRIPTION
* Migrates from old bitnami/rabbitmq to docker.io/library/rabbitmq and bumps rabbitmq to 4.0.
* Removes all external charts
