### PR TITLE
Add tolerations to the fluentd deployment

### DIFF
--- a/templates/fluentd.yaml
+++ b/templates/fluentd.yaml
@@ -213,6 +213,10 @@ spec:
       - name: {{ include "bdba.fullname" . }}-fluentd-config
         configMap:
           name: {{ include "bdba.fullname" . }}-fluentd-config
+      tolerations:
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
I encountered challenges while deploying a Helm chart for my organization. The primary issues were as follows:
The S3 buckets I configured were restricted to allow access exclusively through the IAM instance profile associated with a specific node group. Due to this configuration, only pods scheduled on this node group could access the S3 buckets.
However, since the Fluentd pod did not have proper tolerations specified in the values.yaml file to match the taints applied on the restricted node group, it was scheduled onto other nodes which did not have any taints. Consequently, the Fluentd pod was unable to access the S3 buckets, as it did not inherit the required IAM role permissions provisioned for the node group.
This configuration mismatch caused the deployment process to fail, as Fluentd depended on seamless access to the S3 buckets.