### PR TITLE
Ingress values fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ You can deploy Black Duck Binary Analysis on a Kubernetes cluster by using the H
 
 ## Changes
 
+* Moved hard-coded nginx ingress annotations to configurable `ingress.annotations` in values.yaml.
+* Removed deprecated `kubernetes.io/ingress.class` annotation from ingress templates.
+* Fixed api ingress missing `ingressClassName` when TLS is disabled.
+
 ### 2026.3.0
 * Upgrade frontend container to 2026.3.0 and worker container to 2026.3.0.
 * Upgrade service containers (postgresql 15.17, memcached 1.6.41, rabbitmq 4.1.8).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ You can deploy Black Duck Binary Analysis on a Kubernetes cluster by using the H
 
 ## Changes
 
+* Moved hard-coded nginx ingress annotations to configurable `ingress.annotations` in values.yaml.
+* Removed deprecated `kubernetes.io/ingress.class` annotation from ingress templates.
 * Add support for setting credentials vie helm charts for the Black Duck Portal licensing service.
 * Automatic Global project viewer -permission assignment on login can now be configured with `frontend.saml.globalProjectViewerGroupName`.
 

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,12 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
-    {{- if .Values.ingress.class }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- end }}
 spec:
   {{- if .Values.ingress.class }}
   ingressClassName: {{ .Values.ingress.class }}
@@ -46,19 +40,15 @@ metadata:
   name: {{ $fullName }}-api
   labels:
 {{ include "bdba.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.ingress.annotations .Values.ingress.apiConnLimit }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
+    {{- end }}
     {{- if .Values.ingress.apiConnLimit }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.apiConnLimit | quote }}
     {{- end }}
-    {{- if .Values.ingress.class }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- end }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.tls.enabled }}
   {{- if .Values.ingress.class }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -50,10 +50,10 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls.enabled }}
   {{- if .Values.ingress.class }}
   ingressClassName: {{ .Values.ingress.class }}
   {{- end }}
+{{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.ingress.host | quote }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,12 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
-    {{- if .Values.ingress.class }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- end }}
 spec:
   {{- if .Values.ingress.class }}
   ingressClassName: {{ .Values.ingress.class }}
@@ -46,19 +40,15 @@ metadata:
   name: {{ $fullName }}-api
   labels:
 {{ include "bdba.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.ingress.annotations .Values.ingress.apiConnLimit }}
   annotations:
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
+    {{- end }}
     {{- if .Values.ingress.apiConnLimit }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.apiConnLimit | quote }}
     {{- end }}
-    {{- if .Values.ingress.class }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.class }}
   ingressClassName: {{ .Values.ingress.class }}

--- a/values.yaml
+++ b/values.yaml
@@ -429,6 +429,9 @@ ingress:
     route.openshift.io/termination: "edge"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
   apiConnLimit: 8
   host: "bdba.local"
 

--- a/values.yaml
+++ b/values.yaml
@@ -454,6 +454,9 @@ ingress:
     route.openshift.io/termination: "edge"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/upstream-keepalive-time: "600"
   apiConnLimit: 8
   host: "bdba.local"
 


### PR DESCRIPTION
* Moved hard-coded nginx ingress annotations to configurable `ingress.annotations` in values.yaml.
* Removed deprecated `kubernetes.io/ingress.class` annotation from ingress templates.